### PR TITLE
Support CommonJS projects

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,6 +38,17 @@ Applies all pending migrations in order.
 
 ---
 
+#### Running from a CommonJS project
+`es-migrate` runs and expects ESM. If you have a CommonJS project and
+wish to run `es-migrate`, pass an ESM loader to Node explicitly:
+
+```
+node --loader ts-node/esm node_modules/@ahmetkasap/elasticsearch-migration/dist/cli.js
+```
+`tsx` might work but hasn't been tested.
+
+Your migrations should have the `.mts` or `.mjs` file extensions, not `.ts`.
+
 ### 3. Check Migration Status
 
 ```bash

--- a/src/cli/create.ts
+++ b/src/cli/create.ts
@@ -1,6 +1,5 @@
 import fs from "fs";
 import path from "path";
-import { MigrationService } from "../services/migration.service.js";
 import type { IMigrationConfig } from "../types/migration.interface.js";
 
 export async function createMigration(
@@ -24,7 +23,7 @@ export async function createMigration(
     const fileName = `${timestamp}_${migrationName.replace(
       /[^a-zA-Z0-9]/g,
       "_"
-    )}.ts`;
+    )}.mts`;
     const filePath = path.join(migrationsDir, fileName);
 
     // Migration template

--- a/src/services/migration.service.ts
+++ b/src/services/migration.service.ts
@@ -75,7 +75,9 @@ export class MigrationService {
 
     const files = fs
       .readdirSync(migrationsDir)
-      .filter((file) => file.endsWith(".ts") || file.endsWith(".js"));
+      .filter((file) => {
+        return /\.m?[tj]s$/.test(file);
+      });
 
     const migrations: IMigration[] = [];
 


### PR DESCRIPTION
- Update README with example invocation and usage notes for CJS projects adopting `es-migrate`
- Load .mts and .mjs migration files in addition to .ts and .js
- Generate .mts migrations