### PR TITLE
Fix incorrect package name in migration template

### DIFF
--- a/src/cli/create.ts
+++ b/src/cli/create.ts
@@ -29,7 +29,7 @@ export async function createMigration(
 
     // Migration template
     const migrationTemplate = `import { Client } from "@opensearch-project/opensearch";
-import type { IMigration } from "elastic-migrate";
+import type { IMigration } from '@ahmetkasap/elasticsearch-migration';
 
 const migration: IMigration = {
 	name: "${migrationName}",


### PR DESCRIPTION
Template imports this package as "elastic-migrate", whereas the correct name is "@ahmetkasap/elasticsearch-migration".

thank you @dmurvihill 